### PR TITLE
갑옷 구성 수정 및 오류 해결

### DIFF
--- a/src/main/java/org/kw906plugin/catchTail/commands/Sequence.java
+++ b/src/main/java/org/kw906plugin/catchTail/commands/Sequence.java
@@ -255,14 +255,7 @@ public class Sequence {
         ItemStack leggings = new ItemStack(Material.LEATHER_LEGGINGS);
         ItemStack boots = new ItemStack(Material.LEATHER_BOOTS);
 
-        LeatherArmorMeta helmetsMeta = (LeatherArmorMeta) helmet.getItemMeta();
-        helmetsMeta.setColor(playerData.getColorCode(color));
-        LeatherArmorMeta chestMeta = (LeatherArmorMeta) chest.getItemMeta();
-        chestMeta.setColor(playerData.getColorCode(color));
-        LeatherArmorMeta leggingsMeta = (LeatherArmorMeta) leggings.getItemMeta();
-        leggingsMeta.setColor(playerData.getColorCode(color));
-        LeatherArmorMeta bootsMeta = (LeatherArmorMeta) boots.getItemMeta();
-        bootsMeta.setColor(playerData.getColorCode(color));
+        applyArmors(playerData, color, helmet, chest, leggings, boots);
 
         outPlayer.getInventory().setHelmet(helmet);
         outPlayer.getInventory().setChestplate(chest);

--- a/src/main/java/org/kw906plugin/catchTail/utils/PlayerImpl.java
+++ b/src/main/java/org/kw906plugin/catchTail/utils/PlayerImpl.java
@@ -3,7 +3,11 @@ package org.kw906plugin.catchTail.utils;
 import org.bukkit.Bukkit;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.kw906plugin.catchTail.player.PlayerData;
 
 import static org.bukkit.Bukkit.getOnlinePlayers;
 
@@ -34,5 +38,26 @@ public class PlayerImpl {
             player.heal(20);
             player.setFoodLevel(20);
         }
+    }
+
+    public static void applyArmors(PlayerData playerData, int color, ItemStack helmet, ItemStack chest, ItemStack leggings, ItemStack boots) {
+        LeatherArmorMeta helmetsMeta = setArmorSetting(playerData, color, helmet);
+        LeatherArmorMeta chestMeta = setArmorSetting(playerData, color, chest);
+        LeatherArmorMeta leggingsMeta = setArmorSetting(playerData, color, leggings);
+        LeatherArmorMeta bootsMeta = setArmorSetting(playerData, color, boots);
+
+        helmet.setItemMeta(helmetsMeta);
+        chest.setItemMeta(chestMeta);
+        leggings.setItemMeta(leggingsMeta);
+        boots.setItemMeta(bootsMeta);
+    }
+
+    public static LeatherArmorMeta setArmorSetting(PlayerData playerData, int color, ItemStack armor) {
+        LeatherArmorMeta armorMeta = (LeatherArmorMeta) armor.getItemMeta();
+        armorMeta.setColor(playerData.getColorCode(color));
+        armorMeta.addEnchant(Enchantment.BINDING_CURSE, 1, true);
+        armorMeta.setUnbreakable(true);
+
+        return armorMeta;
     }
 }


### PR DESCRIPTION
FIX: 아웃된 플레이어의 갑옷 색깔이 적용되도록 수정, ADD: 아웃된 플레이어의 갑옷에 귀속 저주 및 갑옷이 깨지지 않도록 수정